### PR TITLE
🔒 Add Security Groups for Web and Database Tiers

### DIFF
--- a/environments/dev/outputs.tf
+++ b/environments/dev/outputs.tf
@@ -22,3 +22,13 @@ output "environment" {
   description = "Environment name"
   value       = var.environment
 }
+
+output "web_security_group_id" {
+  description = "ID of the web security group"
+  value       = aws_security_group.web.id
+}
+
+output "database_security_group_id" {
+  description = "ID of the database security group"
+  value       = aws_security_group.database.id
+}

--- a/environments/dev/security-groups.tf
+++ b/environments/dev/security-groups.tf
@@ -1,0 +1,88 @@
+# Security Groups for Development Environment
+# This demonstrates Atlantis workflow with infrastructure changes
+
+# Web Security Group
+resource "aws_security_group" "web" {
+  name_prefix = "${var.environment}-web-"
+  vpc_id      = aws_vpc.main.id
+  description = "Security group for web servers"
+
+  # HTTP access from anywhere
+  ingress {
+    description = "HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # HTTPS access from anywhere
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # SSH access from VPC only (more secure)
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  # All outbound traffic
+  egress {
+    description = "All outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.environment}-web-sg"
+    Type = "web"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Database Security Group
+resource "aws_security_group" "database" {
+  name_prefix = "${var.environment}-db-"
+  vpc_id      = aws_vpc.main.id
+  description = "Security group for database servers"
+
+  # MySQL/Aurora access from web security group only
+  ingress {
+    description     = "MySQL/Aurora"
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = [aws_security_group.web.id]
+  }
+
+  # PostgreSQL access from web security group only
+  ingress {
+    description     = "PostgreSQL"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.web.id]
+  }
+
+  tags = {
+    Name = "${var.environment}-db-sg"
+    Type = "database"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}


### PR DESCRIPTION
## 🎯 Purpose
This PR demonstrates the complete Atlantis workflow for infrastructure changes with security best practices.

## 🔒 Security Enhancements
- **Web Security Group**: HTTP/HTTPS access from internet, SSH restricted to VPC
- **Database Security Group**: Database access only from web tier (defense in depth)
- **Network Segmentation**: Proper tier isolation following AWS security best practices

## 📋 Infrastructure Changes
- `aws_security_group.web` - Web tier security group
- `aws_security_group.database` - Database tier security group  
- Updated outputs to expose security group IDs
- Lifecycle management to prevent resource conflicts

## 🔍 Security Review Checklist
- [ ] Security groups follow least privilege principle
- [ ] No overly permissive rules (0.0.0.0/0 only where necessary)
- [ ] Proper tier isolation implemented
- [ ] SSH access restricted to VPC CIDR
- [ ] Database access restricted to web tier only

## 🚀 Atlantis Workflow
1. **Plan Phase**: Atlantis will automatically run `terraform plan`
2. **Review Phase**: Security team review required before approval
3. **Apply Phase**: Manual `atlantis apply` after approval

## 📊 Expected Resources
- 2 new security groups
- Proper ingress/egress rules
- Security group references for tier communication

**⚠️ SECURITY NOTICE**: This change requires manual review and approval before infrastructure deployment.